### PR TITLE
fix: add horizontal padding on mobile layouts

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -25,7 +25,7 @@ const { title, description, ogType } = Astro.props;
 
   @media (max-width: 576px) {
     .blog-content {
-      padding: 0;
+      padding: 0 1rem;
     }
   }
 </style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -34,7 +34,7 @@ const { title, description, headerTitle, siteTitle = site.title, ogType } = Astr
 
   @media (max-width: 576px) {
     .container {
-      padding: 0;
+      padding: 0 1rem;
     }
   }
 </style>


### PR DESCRIPTION
## Description

- `PageLayout` and `BlogLayout` both set `padding: 0` on mobile (`max-width: 576px`), causing content to touch the screen edges with no horizontal margin
- Changed to `padding: 0 1rem` for both layouts

## Testing

- Manual: verified pages/blog content has consistent side margins on mobile widths
- `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)