### PR TITLE
feat: remove projects banner and add 2025 faves list

### DIFF
--- a/src/data/favourites/movies.ts
+++ b/src/data/favourites/movies.ts
@@ -22,6 +22,7 @@ export interface FeaturedList {
 
 export const featuredLists: FeaturedList[] = [
   { name: '2026 Faves', url: 'https://letterboxd.com/cdmt/list/2026_faves/' },
+  { name: '2025 Faves', url: 'https://letterboxd.com/cdmt/list/2025_faves/' },
   { name: 'Real Good Hope', url: 'https://letterboxd.com/cdmt/list/real-good-hope/' },
   {
     name: "They Don't Go Anywhere",

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -12,21 +12,6 @@ const projects = projectsData.projects;
   description="Personal projects."
   headerTitle="projects"
 >
-  <div class="banner" data-banner>
-    <p class="banner-text" data-banner-default>
-      None of these projects are actively maintained. They are preserved here for reference.
-    </p>
-    <p class="banner-text" data-banner-sharks>
-      These players have been sent to the press box. No longer on the active roster.
-    </p>
-    <p class="banner-text" data-banner-canada>
-      Sorry, none of these projects are actively maintained, eh. They're preserved here for
-      reference.
-    </p>
-    <p class="banner-text" data-banner-underwater>
-      These vessels have been scuttled. They rest on the ocean floor for exploration.
-    </p>
-  </div>
   <section class="projects">
     {projects.map((project, i) => <ProjectCard {...project} index={i} />)}
   </section>
@@ -39,34 +24,5 @@ const projects = projectsData.projects;
     justify-content: center;
     box-sizing: content-box;
     padding: 1rem 0;
-  }
-
-  .banner {
-    margin: 1rem auto;
-    max-width: 600px;
-    padding: 0.75rem 1.25rem;
-    border: var(--banner-border);
-    border-radius: var(--banner-radius);
-    background-color: var(--banner-bg);
-    text-align: center;
-    transition:
-      border 0.3s ease,
-      background-color 0.3s ease,
-      border-radius 0.3s ease;
-  }
-
-  .banner-text {
-    margin: 0;
-    font-size: 0.9rem;
-    color: var(--color-text);
-  }
-</style>
-
-<style is:global>
-  /* Theme-specific banner text — hidden by default, shown by theme CSS */
-  [data-banner-sharks],
-  [data-banner-canada],
-  [data-banner-underwater] {
-    display: none;
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,11 +164,6 @@ table {
   /* Card link tokens */
   --card-link-border: none;
   --card-link-padding-top: 0;
-
-  /* Banner tokens */
-  --banner-border: 1px solid var(--color-secondary);
-  --banner-bg: var(--color-bg);
-  --banner-radius: 3px;
 }
 
 /* Global styles */

--- a/src/themes/definitions/canada.ts
+++ b/src/themes/definitions/canada.ts
@@ -79,9 +79,6 @@ export default {
     '--header-border': `2px solid ${PALETTE.whiteHalf}`,
     '--card-link-border': `1px dashed ${PALETTE.whiteTint + '8'}`,
     '--card-link-padding-top': '0.5rem',
-    '--banner-border': `2px solid ${PALETTE.whiteHalf}`,
-    '--banner-bg': PALETTE.whiteGhost,
-    '--banner-radius': '6px',
   },
 
   pageContent: {
@@ -247,8 +244,6 @@ export default {
     ${THEME_SELECTOR} [data-card-detail] { font-style: italic; }
     ${THEME_SELECTOR} [data-card-detail]::before { content: 'Ingredients: '; font-style: normal; font-weight: bold; font-size: 0.75rem; }
 
-    ${THEME_SELECTOR} [data-banner-default] { display: none !important; }
-    ${THEME_SELECTOR} [data-banner-canada] { display: block !important; }
     ${THEME_SELECTOR} [data-404] { display: none !important; }
     ${THEME_SELECTOR} [data-404="${THEME_ID}"] { display: block !important; }
   `,

--- a/src/themes/definitions/sharks.ts
+++ b/src/themes/definitions/sharks.ts
@@ -66,9 +66,6 @@ export default {
     '--header-border': '3px solid',
     '--card-link-border': `1px solid ${PALETTE.orangeBorder}`,
     '--card-link-padding-top': '0.5rem',
-    '--banner-border': `2px solid ${PALETTE.orange}`,
-    '--banner-bg': `linear-gradient(180deg, ${PALETTE.scoreTeal} 0%, ${PALETTE.midTeal} 100%)`,
-    '--banner-radius': '3px',
   },
 
   pageContent: {
@@ -172,9 +169,6 @@ export default {
     ${THEME_SELECTOR} [data-card-name] { text-transform: uppercase; letter-spacing: 0.03em; font-size: 1.15em; }
     ${THEME_SELECTOR} [data-card-detail] { display: inline-flex; flex-wrap: wrap; gap: 4px; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; }
 
-    ${THEME_SELECTOR} [data-banner] { text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.85rem; }
-    ${THEME_SELECTOR} [data-banner-default] { display: none !important; }
-    ${THEME_SELECTOR} [data-banner-sharks] { display: block !important; }
     ${THEME_SELECTOR} [data-404] { display: none !important; }
     ${THEME_SELECTOR} [data-404="${THEME_ID}"] { display: block !important; }
   `,

--- a/src/themes/definitions/underwater.ts
+++ b/src/themes/definitions/underwater.ts
@@ -236,9 +236,6 @@ export default {
     '--header-border': '2px solid transparent',
     '--card-link-border': '1px solid rgba(0, 184, 148, 0.2)',
     '--card-link-padding-top': '0.5rem',
-    '--banner-border': '1px solid rgba(0, 184, 148, 0.4)',
-    '--banner-bg': 'rgba(0, 184, 148, 0.08)',
-    '--banner-radius': '8px',
   },
 
   pageContent: {
@@ -622,8 +619,6 @@ export default {
     }
     ${THEME_SELECTOR} [data-card-detail] { color: #7ec8d9; font-size: 0.75rem; }
 
-    ${THEME_SELECTOR} [data-banner-default] { display: none !important; }
-    ${THEME_SELECTOR} [data-banner-underwater] { display: block !important; }
     ${THEME_SELECTOR} [data-404] { display: none !important; }
     ${THEME_SELECTOR} [data-404="${THEME_ID}"] { display: block !important; }
   `,

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -70,9 +70,6 @@ export interface ThemeColors {
   '--header-border'?: string;
   '--card-link-border'?: string;
   '--card-link-padding-top'?: string;
-  '--banner-border'?: string;
-  '--banner-bg'?: string;
-  '--banner-radius'?: string;
 }
 
 /** Content displayed on the 404 page for a given theme. */


### PR DESCRIPTION
## Description

- Remove the themed banner from the projects page, including all banner-related CSS tokens, theme color overrides (`--banner-border`, `--banner-bg`, `--banner-radius`), theme-specific banner text visibility rules, and the `ThemeColors` type definitions
- Add "2025 Faves" to the featured movie lists on the faves page

## Testing

- Verified projects page renders without the banner
- Verified each theme (default, sharks, canada, underwater) no longer references banner tokens
- Verified 2025 Faves appears in the featured lists