### PR TITLE
feat: add hidden /facts page

### DIFF
--- a/src/data/facts.ts
+++ b/src/data/facts.ts
@@ -1,0 +1,45 @@
+export interface Fact {
+  text: string;
+  source?: string;
+}
+
+export interface FactSection {
+  id: string;
+  title: string;
+  description?: string;
+  facts: Fact[];
+}
+
+const sections: FactSection[] = [
+  {
+    id: 'rock-facts',
+    title: 'Rock facts',
+    description:
+      '<a href="https://en.wikipedia.org/wiki/Over_the_Garden_Wall">Greg</a> told me these ones.',
+    facts: [
+      {
+        text: "Dinosaurs had big ears, but everyone forgot this because dinosaur ears don't have bones.",
+      },
+      { text: 'If you soak a raisin in grape juice, it turns into a grape.' },
+      { text: 'Did you know that computers are powered by lots of tiny calculators?' },
+      { text: 'There are more airplanes in the ocean than submarines in the sky.' },
+      { text: 'If you stacked every elephant on earth on top of each other, they would all die.' },
+    ],
+  },
+  {
+    id: 'real-facts',
+    title: 'Real facts',
+    description: 'Pretty sure.',
+    facts: [
+      {
+        text: 'Hockey players use smelling salts to wake themselves up during games. These smell like ammonia. Cat litter also smells like ammonia. Therefore, all hockey players are cat people.',
+      },
+      { text: 'Saddam Hussein was given a key to the city of Detroit.' },
+      {
+        text: 'The <a href="https://en.wikipedia.org/wiki/Jimi_Heselden">inventor</a> of the Segway died after driving a Segway off a cliff.',
+      },
+    ],
+  },
+];
+
+export default sections;

--- a/src/pages/facts.astro
+++ b/src/pages/facts.astro
@@ -1,0 +1,249 @@
+---
+import DefaultLayout from '../layouts/DefaultLayout.astro';
+import { site } from '../data/site';
+import sections from '../data/facts';
+---
+
+<DefaultLayout
+  title={`${site.title} - facts`}
+  description="Facts, anti-jokes, and questionable anecdotes."
+>
+  <div class="facts">
+    <header class="page-header">
+      <h1 class="page-title">facts</h1>
+    </header>
+
+    <nav class="section-nav">
+      {
+        sections.map((section) => (
+          <a href={`#${section.id}`} class="nav-pill">
+            {section.title}
+          </a>
+        ))
+      }
+      <button class="random-fact-btn" id="random-fact">Random</button>
+    </nav>
+
+    {
+      sections.map((section) => (
+        <section id={section.id} class="fact-section">
+          <div class="section-heading">
+            <h2 class="section-title">{section.title}</h2>
+            {section.description && <p class="section-desc" set:html={section.description} />}
+          </div>
+          <ul class="fact-list">
+            {section.facts.map((fact) => (
+              <li class="fact-item">
+                <span class="fact-text" set:html={fact.text} />
+                {fact.source && <span class="fact-source">— {fact.source}</span>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+  </div>
+</DefaultLayout>
+
+<style is:global>
+  .theme-switcher {
+    display: none !important;
+  }
+</style>
+
+<style>
+  .facts {
+    width: 100%;
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  .page-header {
+    margin-bottom: 2rem;
+  }
+
+  .page-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text);
+    margin: 0 0 0.4rem;
+  }
+
+  .page-subtitle {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* Section nav */
+  .section-nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .nav-pill {
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    padding: 0.25rem 0.6rem;
+    border-radius: 100px;
+    border: 1px solid var(--color-border);
+    transition:
+      color 0.15s,
+      border-color 0.15s;
+  }
+
+  .nav-pill:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-secondary);
+  }
+
+  .random-fact-btn {
+    margin-left: auto;
+    background: var(--color-primary);
+    color: var(--color-bg);
+    border: none;
+    padding: 0.25rem 0.65rem;
+    border-radius: 100px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    transition:
+      background 0.15s,
+      transform 0.1s;
+  }
+
+  .random-fact-btn:hover {
+    background: var(--color-primary-hover);
+    transform: translateY(-1px);
+  }
+
+  .random-fact-btn:active {
+    transform: translateY(0);
+  }
+
+  /* Sections */
+  .fact-section {
+    margin-bottom: 2.5rem;
+  }
+
+  .section-heading {
+    margin-bottom: 1rem;
+  }
+
+  .section-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  .section-desc {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+    margin: 0.2rem 0 0;
+    line-height: 1.4;
+  }
+
+  /* Fact list */
+  .fact-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .fact-item {
+    padding: 0.65rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    transition: background 0.15s;
+  }
+
+  .fact-item:first-child {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .fact-item:hover {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  .fact-text {
+    font-size: 0.85rem;
+    color: var(--color-text);
+    line-height: 1.5;
+  }
+
+  .fact-source {
+    display: block;
+    font-size: 0.72rem;
+    color: var(--color-text-muted);
+    margin-top: 0.25rem;
+    font-style: italic;
+  }
+
+  /* Highlight state for random */
+  :global(.fact-item.highlight) {
+    background: rgba(var(--color-primary-rgb, 99, 102, 241), 0.08);
+    border-color: var(--color-primary);
+  }
+
+  :global(.fact-item.highlight) + .fact-item {
+    border-top-color: var(--color-primary);
+  }
+
+  /* Responsive */
+  @media (max-width: 640px) {
+    .facts {
+      padding: 1.25rem 1rem 3rem;
+    }
+
+    .page-title {
+      font-size: 1.25rem;
+    }
+
+    .section-nav {
+      gap: 0.35rem;
+    }
+
+    .nav-pill {
+      font-size: 0.68rem;
+      padding: 0.2rem 0.5rem;
+    }
+  }
+</style>
+
+<script>
+  // Random fact highlight
+  document.querySelector('#random-fact')?.addEventListener('click', () => {
+    const allFacts = document.querySelectorAll<HTMLElement>('.fact-item');
+    if (allFacts.length === 0) return;
+
+    for (const f of allFacts) f.classList.remove('highlight');
+
+    const pick = allFacts[Math.floor(Math.random() * allFacts.length)];
+    pick.classList.add('highlight');
+    pick.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+
+  // Smooth scroll for nav pills
+  for (const pill of document.querySelectorAll<HTMLAnchorElement>('.nav-pill')) {
+    pill.addEventListener('click', (e) => {
+      e.preventDefault();
+      const id = pill.getAttribute('href')?.slice(1);
+      if (id) {
+        document.querySelector(`#${id}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  }
+</script>


### PR DESCRIPTION
## Description

Add a secret `/facts` page for silly facts, anti-jokes, and personal anecdotes (similar to the existing `/faves` page). Sections and content are driven by `src/data/facts.ts` for easy editing. Supports HTML in descriptions and fact text for inline links.

Features:
- Pill navigation for jumping between sections
- Random fact button
- Responsive, mobile-optimized layout

## Testing

- Verified page renders at `/facts` with all sections
- Verified HTML links render correctly in descriptions and fact text
- Verified random fact button highlights and scrolls to a fact
- Verified responsive layout on mobile viewport
- Verified build passes