### PR TITLE
refactor: design tokens, utility classes, secret pages, MediaCard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 ## Testing
 
-<!-- How was this tested? Use a bullet point list, not checkboxes. -->
+<!-- How was this tested? Use a bullet point list, not checkboxes. Omit prefixing every list item with "Verified.." or "tested...". -->

--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -1,5 +1,6 @@
 ---
 import { site } from '../data/site';
+import { secretPages } from '../data/secret';
 
 interface Props {
   title?: string;
@@ -20,8 +21,52 @@ const headerClass = [
 ---
 
 <h1 class={headerClass}>
-  <a href="/" class="link">{title}</a>
+  <a href="/" class="link" data-brand>{title}</a>
+  <div class="secret-dropdown" data-secret-dropdown>
+    {
+      secretPages.map((page) => (
+        <a href={page.path} class="secret-link">
+          {page.name}
+        </a>
+      ))
+    }
+  </div>
 </h1>
+
+<script>
+  import { onMultiTap } from '../utils/multiTap';
+
+  const isHomePage = globalThis.location.pathname === '/';
+  const brand = document.querySelector<HTMLElement>('[data-brand]');
+  const dropdown = document.querySelector<HTMLElement>('[data-secret-dropdown]');
+
+  if (isHomePage && brand && dropdown) {
+    const show = () => {
+      dropdown.dataset.visible = '';
+    };
+    const hide = () => {
+      delete dropdown.dataset.visible;
+    };
+    const toggle = () => ('visible' in dropdown.dataset ? hide() : show());
+
+    // Hover for 3 seconds
+    let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+    brand.addEventListener('mouseenter', () => {
+      hoverTimer = setTimeout(show, 3000);
+    });
+    brand.addEventListener('mouseleave', () => {
+      if (hoverTimer) clearTimeout(hoverTimer);
+    });
+
+    // Triple tap (only on home page)
+    onMultiTap(brand, toggle, { taps: 3 });
+
+    // Close when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!brand.closest('h1')?.contains(e.target as Node)) hide();
+    });
+  }
+</script>
 
 <style>
   .header {
@@ -29,6 +74,7 @@ const headerClass = [
     margin: 0;
     padding: 0 4px;
     cursor: default;
+    position: relative;
   }
 
   .header-large {
@@ -48,6 +94,25 @@ const headerClass = [
 
   .link:hover {
     color: var(--color-text-secondary) !important;
+  }
+
+  [data-secret-dropdown] {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    flex-direction: column;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-xs);
+    box-shadow: var(--shadow-dropdown);
+    z-index: 200;
+    min-width: 80px;
+  }
+
+  [data-secret-dropdown][data-visible] {
+    display: flex;
   }
 
   @media (max-width: 576px) {

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -20,7 +20,7 @@ const { title, siteTitle = site.title } = Astro.props;
     <a href="/projects" class="desktop-menu-item">projects</a>
   </nav>
   <span class="mobile-menu">
-    <button class="hamburger-btn" aria-label="Toggle menu" aria-expanded="false">
+    <button class="hamburger-btn btn-reset" aria-label="Toggle menu" aria-expanded="false">
       <span class="bar"></span>
       <span class="bar"></span>
       <span class="bar"></span>
@@ -63,7 +63,7 @@ const { title, siteTitle = site.title } = Astro.props;
     line-height: 50px;
     align-items: center;
     border-bottom: var(--header-border);
-    transition: border-bottom 0.3s ease;
+    transition: border-bottom var(--transition-normal) ease;
     position: relative;
   }
 
@@ -101,9 +101,6 @@ const { title, siteTitle = site.title } = Astro.props;
     justify-content: space-around;
     width: 24px;
     height: 20px;
-    background: transparent;
-    border: none;
-    cursor: pointer;
     padding: 0;
   }
 
@@ -112,7 +109,7 @@ const { title, siteTitle = site.title } = Astro.props;
     width: 100%;
     height: 1px;
     background-color: var(--color-text);
-    transition: all 0.25s ease;
+    transition: all var(--transition-fast) ease;
     transform-origin: center;
   }
 
@@ -143,7 +140,7 @@ const { title, siteTitle = site.title } = Astro.props;
     padding: 0.5em;
     font-size: 1.4rem;
     background-color: var(--color-bg-surface);
-    box-shadow: 3px 3px 6px rgba(15, 15, 15, 0.5);
+    box-shadow: var(--shadow-dropdown);
     z-index: 100;
   }
 
@@ -163,7 +160,7 @@ const { title, siteTitle = site.title } = Astro.props;
     height: 100%;
     background-color: rgb(75, 75, 75);
     opacity: 0;
-    transition: opacity 0.2s ease-in-out;
+    transition: opacity var(--transition-fast) ease-in-out;
     pointer-events: none;
     z-index: 50;
   }

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -33,10 +33,10 @@ const jerseyNumber = String(index + 1).padStart(2, '0');
     display: flex;
     flex-direction: column;
     width: 100%;
-    padding: 1rem;
-    margin: 0.5rem;
+    padding: var(--space-md);
+    margin: var(--space-sm);
     transition: top ease 1s;
-    border-radius: 3px;
+    border-radius: var(--radius-sm);
     background-color: var(--color-bg-surface);
     box-shadow: var(--shadow-button);
   }
@@ -67,12 +67,12 @@ const jerseyNumber = String(index + 1).padStart(2, '0');
 
   .short-description {
     margin: 0.35rem 0;
-    font-size: 0.9rem;
+    font-size: var(--text-base);
     height: 2rem;
   }
 
   .detail {
-    font-size: 0.8rem;
+    font-size: var(--text-sm);
     color: var(--color-text-secondary);
     margin: 0.25rem 0;
   }
@@ -83,7 +83,7 @@ const jerseyNumber = String(index + 1).padStart(2, '0');
     margin-top: auto;
     padding-top: var(--card-link-padding-top);
     border-top: var(--card-link-border);
-    transition: border-top 0.3s ease;
+    transition: border-top var(--transition-normal) ease;
   }
 
   .link {

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -17,17 +17,17 @@
 <style>
   .scroll-to-top {
     position: fixed;
-    bottom: 70px;
+    bottom: 20px;
     right: 20px;
     background-color: var(--color-bg-surface);
     border: 1px solid var(--color-accent);
-    border-radius: 3px;
-    padding: 0.35rem;
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs);
     cursor: pointer;
     opacity: 0;
     transition:
-      opacity 0.3s ease,
-      top 0.3s ease;
+      opacity var(--transition-normal) ease,
+      top var(--transition-normal) ease;
     pointer-events: none;
     z-index: 200;
     font-family: inherit;

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -3,7 +3,7 @@
 ---
 
 <div class="theme-switcher" data-theme-ui>
-  <button class="theme-btn" aria-label="Change theme" aria-expanded="false">
+  <button class="theme-btn icon-btn" aria-label="Change theme" aria-expanded="false">
     <svg width="16" height="16" viewBox="0 0 512 512" fill="currentColor">
       <path
         d="M512 256c0 .9 0 1.8 0 2.7c-.4 36.5-33.6 61.3-70.1 61.3H344c-26.5 0-48 21.5-48 48c0 8.8 2.4 17.4 6.7 25.1l2.4 4.4c15.5 28 2.1 63.5-28.3 73.6C254 478 228.1 484 200.7 484C106.5 484 28 409.7 28 320C28 165.3 144.7 44 296.3 44c81 0 153.2 38.2 200.5 97.5c6.2 7.8 15.2 22.5 15.2 40.5v74zM152 256c-22.1 0-40 17.9-40 40s17.9 40 40 40s40-17.9 40-40s-17.9-40-40-40zm-8-128c-22.1 0-40 17.9-40 40s17.9 40 40 40s40-17.9 40-40s-17.9-40-40-40zm168-24c-22.1 0-40 17.9-40 40s17.9 40 40 40s40-17.9 40-40s-17.9-40-40-40zm120 112c-22.1 0-40 17.9-40 40s17.9 40 40 40s40-17.9 40-40s-17.9-40-40-40z"
@@ -82,18 +82,9 @@
   }
 
   .theme-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    border: 1px solid var(--color-border);
-    background-color: var(--color-bg-surface);
     color: var(--color-text);
-    cursor: pointer;
     box-shadow: var(--shadow-button);
-    transition: transform 0.2s ease;
+    transition: transform var(--transition-fast) ease;
   }
 
   .theme-btn:hover {
@@ -107,16 +98,16 @@
     min-width: 120px;
     background-color: var(--color-bg-surface);
     border: 1px solid var(--color-border);
-    border-radius: 6px;
+    border-radius: var(--radius-lg);
     box-shadow: var(--shadow-button);
     overflow: hidden;
     opacity: 0;
     visibility: hidden;
     transform: translateY(4px);
     transition:
-      opacity 0.15s ease,
-      transform 0.15s ease,
-      visibility 0.15s ease;
+      opacity var(--transition-fast) ease,
+      transform var(--transition-fast) ease,
+      visibility var(--transition-fast) ease;
     display: flex;
     flex-direction: column;
   }
@@ -130,16 +121,16 @@
   }
 
   .theme-option {
-    padding: 8px 12px;
+    padding: var(--space-sm) var(--space-md);
     border: none;
     text-align: left;
     cursor: pointer;
     font-family: inherit;
-    font-size: 0.85rem;
+    font-size: var(--text-base);
     font-weight: 600;
     transition:
-      opacity 0.15s ease,
-      padding-left 0.15s ease;
+      opacity var(--transition-fast) ease,
+      padding-left var(--transition-fast) ease;
   }
 
   .theme-option:hover {

--- a/src/components/faves/MediaCard.astro
+++ b/src/components/faves/MediaCard.astro
@@ -1,0 +1,130 @@
+---
+interface Props {
+  name: string;
+  year: number;
+  cover: string;
+  subtitle: string;
+  extra?: string;
+  href?: string;
+  aspectRatio?: string;
+}
+
+const { name, year, cover, subtitle, extra, href, aspectRatio = '2 / 3' } = Astro.props;
+---
+
+<div class="media-card" data-year={year}>
+  {
+    href ? (
+      <a href={href} class="media-link" target="_blank" rel="noopener noreferrer">
+        <img
+          src={cover}
+          alt={name}
+          class="media-img"
+          style={`aspect-ratio: ${aspectRatio}`}
+          loading="lazy"
+        />
+      </a>
+    ) : (
+      <img
+        src={cover}
+        alt={name}
+        class="media-img"
+        style={`aspect-ratio: ${aspectRatio}`}
+        loading="lazy"
+      />
+    )
+  }
+  <div class="media-info flex-col">
+    <span class="media-name">{name}</span>
+    <span class="media-meta">{subtitle}</span>
+    {extra && <span class="media-extra">{extra}</span>}
+  </div>
+</div>
+
+<style>
+  .media-card {
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    color: inherit;
+    transition: transform var(--transition-fast);
+  }
+
+  .media-link {
+    display: block;
+  }
+
+  .media-card:hover .media-img {
+    opacity: 0.85;
+  }
+
+  .media-img {
+    width: 100%;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    transition: opacity var(--transition-fast);
+    background: var(--faves-shimmer, var(--color-bg-surface));
+    animation: pulse 2.5s ease-in-out infinite;
+  }
+
+  .media-img[data-loaded] {
+    animation: none;
+    background: none;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.6;
+    }
+  }
+
+  .media-info {
+    padding-top: 0.3rem;
+  }
+
+  .media-name {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+    line-height: 1.25;
+  }
+
+  .media-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    line-height: 1.3;
+  }
+
+  .media-extra {
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
+</style>
+
+<style is:global>
+  .dark .media-img {
+    --faves-shimmer: #323238;
+  }
+
+  .media-card.highlight {
+    transform: scale(1.04);
+    z-index: 1;
+  }
+
+  .media-card.highlight .media-img {
+    outline: 3px solid var(--color-primary);
+    outline-offset: 2px;
+    box-shadow:
+      0 0 12px var(--color-primary),
+      0 4px 16px rgba(0, 0, 0, 0.3);
+    border-radius: var(--radius-sm);
+  }
+
+  .media-card.highlight .media-name {
+    color: var(--color-primary);
+  }
+</style>

--- a/src/data/secret.ts
+++ b/src/data/secret.ts
@@ -1,0 +1,10 @@
+export interface SecretPage {
+  name: string;
+  path: string;
+  description: string;
+}
+
+export const secretPages: SecretPage[] = [
+  { name: 'faves', path: '/faves', description: 'A few of my favourite things.' },
+  { name: 'facts', path: '/facts', description: 'Facts, anti-jokes, and questionable anecdotes.' },
+];

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -18,14 +18,14 @@ const { title, description, ogType } = Astro.props;
 
 <style>
   .blog-content {
-    padding: 0 1.25rem;
+    padding: 0 var(--space-md);
     min-width: 40vw;
     max-width: 100%;
   }
 
   @media (max-width: 576px) {
     .blog-content {
-      padding: 0 1rem;
+      padding: 0 var(--space-md);
     }
   }
 </style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -26,7 +26,7 @@ const { title, description, headerTitle, siteTitle = site.title, ogType } = Astr
     margin: 0 auto;
     width: 100%;
     max-width: 50rem;
-    padding: 0 1.3125rem 2.625rem;
+    padding: 0 var(--space-md) var(--space-lg);
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -34,7 +34,7 @@ const { title, description, headerTitle, siteTitle = site.title, ogType } = Astr
 
   @media (max-width: 576px) {
     .container {
-      padding: 0 1rem;
+      padding: 0 var(--space-md);
     }
   }
 </style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,7 +6,7 @@ const themeEntries = Object.entries(themes);
 ---
 
 <PageLayout title="404" description="This page is missing." headerTitle="404">
-  <div class="container">
+  <div class="container flex-center">
     {
       themeEntries.map(([id, theme]) =>
         theme.pageContent?.notFoundPage ? (
@@ -18,28 +18,37 @@ const themeEntries = Object.entries(themes);
       )
     }
     <a href="/" class="home-link">Go home</a>
+    <a href="/secret" class="hidden-link" aria-label="Secret">.</a>
   </div>
 </PageLayout>
 
 <style>
   .container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 2rem;
+    padding: var(--space-lg);
     text-align: center;
   }
 
   .truth {
-    margin-top: 1rem;
-    font-size: 0.9rem;
+    margin-top: var(--space-md);
+    font-size: var(--text-base);
     color: var(--color-text-secondary);
   }
 
   .home-link {
-    margin-top: 2rem;
-    font-size: 0.9rem;
+    margin-top: var(--space-lg);
+    font-size: var(--text-base);
+  }
+
+  .hidden-link {
+    margin-top: var(--space-lg);
+    color: var(--color-bg);
+    text-decoration: none;
+    font-size: 0.5rem;
+    transition: color var(--transition-normal);
+  }
+
+  .hidden-link:hover {
+    color: var(--color-text-muted);
   }
 </style>
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -55,7 +55,7 @@ const { Content } = await render(post);
   }
 
   .date {
-    font-size: 0.75rem;
+    font-size: var(--text-sm);
   }
 
   .content {

--- a/src/pages/facts.astro
+++ b/src/pages/facts.astro
@@ -9,34 +9,27 @@ import sections from '../data/facts';
   description="Facts, anti-jokes, and questionable anecdotes."
 >
   <div class="facts">
-    <header class="page-header">
-      <h1 class="page-title">facts</h1>
-    </header>
+    <h1>facts</h1>
 
     <nav class="section-nav">
       {
         sections.map((section) => (
-          <a href={`#${section.id}`} class="nav-pill">
+          <a href={`#${section.id}`} class="nav-pill link-quiet">
             {section.title}
           </a>
         ))
       }
-      <button class="random-fact-btn" id="random-fact">Random</button>
+      <button class="random-fact-btn" id="random-fact">Choose a random fact</button>
     </nav>
 
     {
       sections.map((section) => (
-        <section id={section.id} class="fact-section">
-          <div class="section-heading">
-            <h2 class="section-title">{section.title}</h2>
-            {section.description && <p class="section-desc" set:html={section.description} />}
-          </div>
-          <ul class="fact-list">
+        <section id={section.id}>
+          <h2>{section.title}</h2>
+          {section.description && <p set:html={section.description} />}
+          <ul>
             {section.facts.map((fact) => (
-              <li class="fact-item">
-                <span class="fact-text" set:html={fact.text} />
-                {fact.source && <span class="fact-source">— {fact.source}</span>}
-              </li>
+              <li set:html={fact.text} />
             ))}
           </ul>
         </section>
@@ -45,36 +38,16 @@ import sections from '../data/facts';
   </div>
 </DefaultLayout>
 
-<style is:global>
-  .theme-switcher {
-    display: none !important;
-  }
-</style>
-
 <style>
   .facts {
-    width: 100%;
     max-width: 42rem;
     margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
+    padding: var(--space-lg) var(--space-lg) var(--space-xl);
   }
 
-  .page-header {
-    margin-bottom: 2rem;
-  }
-
-  .page-title {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--color-text);
-    margin: 0 0 0.4rem;
-  }
-
-  .page-subtitle {
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-    margin: 0;
-    line-height: 1.5;
+  .facts h1 {
+    font-size: var(--text-xl);
+    margin: 0 0 var(--space-md);
   }
 
   /* Section nav */
@@ -82,23 +55,21 @@ import sections from '../data/facts';
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.4rem;
-    margin-bottom: 2rem;
-    padding-bottom: 1rem;
+    justify-content: center;
+    gap: var(--space-xs);
+    padding-bottom: var(--space-md);
+    margin-bottom: var(--space-lg);
     border-bottom: 1px solid var(--color-border);
   }
 
   .nav-pill {
-    font-size: 0.72rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     color: var(--color-text-muted);
-    text-decoration: none;
-    padding: 0.25rem 0.6rem;
-    border-radius: 100px;
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-full);
     border: 1px solid var(--color-border);
-    transition:
-      color 0.15s,
-      border-color 0.15s;
+    transition: border-color var(--transition-fast);
   }
 
   .nav-pill:hover {
@@ -107,19 +78,16 @@ import sections from '../data/facts';
   }
 
   .random-fact-btn {
-    margin-left: auto;
+    margin: auto;
     background: var(--color-primary);
     color: var(--color-bg);
     border: none;
-    padding: 0.25rem 0.65rem;
-    border-radius: 100px;
-    font-size: 0.68rem;
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-full);
+    font-size: var(--text-xs);
     font-weight: 600;
     cursor: pointer;
-    letter-spacing: 0.03em;
-    transition:
-      background 0.15s,
-      transform 0.1s;
+    transition: background var(--transition-fast);
   }
 
   .random-fact-btn:hover {
@@ -127,106 +95,50 @@ import sections from '../data/facts';
     transform: translateY(-1px);
   }
 
-  .random-fact-btn:active {
-    transform: translateY(0);
-  }
-
   /* Sections */
-  .fact-section {
-    margin-bottom: 2.5rem;
+  .facts section {
+    margin-bottom: var(--space-lg);
   }
 
-  .section-heading {
-    margin-bottom: 1rem;
-  }
-
-  .section-title {
-    font-size: 1rem;
-    font-weight: 700;
-    color: var(--color-text);
+  .facts section h2 {
+    font-size: var(--text-md);
     margin: 0;
   }
 
-  .section-desc {
-    font-size: 0.78rem;
+  .facts section h2 + p {
+    font-size: var(--text-sm);
     color: var(--color-text-muted);
     margin: 0.2rem 0 0;
-    line-height: 1.4;
   }
 
-  /* Fact list */
-  .fact-list {
+  .facts section ul {
     list-style: none;
-    margin: 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-  }
-
-  .fact-item {
-    padding: 0.65rem 0.75rem;
-    border-bottom: 1px solid var(--color-border);
-    transition: background 0.15s;
-  }
-
-  .fact-item:first-child {
+    margin: var(--space-md) 0 0;
     border-top: 1px solid var(--color-border);
   }
 
-  .fact-item:hover {
+  .facts section li {
+    padding: var(--space-sm) var(--space-sm);
+    font-size: var(--text-base);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .facts section li:hover {
     background: rgba(0, 0, 0, 0.02);
   }
 
-  .fact-text {
-    font-size: 0.85rem;
-    color: var(--color-text);
-    line-height: 1.5;
-  }
-
-  .fact-source {
-    display: block;
-    font-size: 0.72rem;
-    color: var(--color-text-muted);
-    margin-top: 0.25rem;
-    font-style: italic;
-  }
-
   /* Highlight state for random */
-  :global(.fact-item.highlight) {
+  :global(.facts section li.highlight) {
     background: rgba(var(--color-primary-rgb, 99, 102, 241), 0.08);
     border-color: var(--color-primary);
-  }
-
-  :global(.fact-item.highlight) + .fact-item {
-    border-top-color: var(--color-primary);
-  }
-
-  /* Responsive */
-  @media (max-width: 640px) {
-    .facts {
-      padding: 1.25rem 1rem 3rem;
-    }
-
-    .page-title {
-      font-size: 1.25rem;
-    }
-
-    .section-nav {
-      gap: 0.35rem;
-    }
-
-    .nav-pill {
-      font-size: 0.68rem;
-      padding: 0.2rem 0.5rem;
-    }
   }
 </style>
 
 <script>
   // Random fact highlight
   document.querySelector('#random-fact')?.addEventListener('click', () => {
-    const allFacts = document.querySelectorAll<HTMLElement>('.fact-item');
+    const allFacts = document.querySelectorAll<HTMLElement>('.facts section li');
     if (allFacts.length === 0) return;
 
     for (const f of allFacts) f.classList.remove('highlight');

--- a/src/pages/faves.astro
+++ b/src/pages/faves.astro
@@ -1,5 +1,6 @@
 ---
 import DefaultLayout from '../layouts/DefaultLayout.astro';
+import MediaCard from '../components/faves/MediaCard.astro';
 import { site } from '../data/site';
 import { moviesByGenre, featuredLists } from '../data/favourites/movies';
 import { miniSeries, fullSeries } from '../data/favourites/tv';
@@ -29,10 +30,10 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   <div class="faves">
     <nav class="toolbar" id="toolbar">
       <div class="toolbar-tabs">
-        <a href="#movies" class="tab-link active" data-tab>Movies</a>
-        <a href="#tv-series" class="tab-link" data-tab>TV</a>
-        <a href="#tv-mini" class="tab-link" data-tab>Mini Series</a>
-        <a href="#music" class="tab-link" data-tab>Albums</a>
+        <a href="#movies" class="tab-link link-quiet active" data-tab>Movies</a>
+        <a href="#tv-series" class="tab-link link-quiet" data-tab>TV</a>
+        <a href="#tv-mini" class="tab-link link-quiet" data-tab>Mini Series</a>
+        <a href="#music" class="tab-link link-quiet" data-tab>Albums</a>
       </div>
       <div class="toolbar-controls">
         <div class="view-dropdown" id="view-dropdown">
@@ -65,7 +66,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
             </svg>
           </button>
           <div class="view-menu" id="view-menu" role="menu">
-            <button class="view-option active" data-view="full" role="menuitem">
+            <button class="view-option btn-reset active" data-view="full" role="menuitem">
               <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"
                 ><rect x="1" y="1" width="6" height="6" rx="1"></rect><rect
                   x="9"
@@ -81,7 +82,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
               >
               Full
             </button>
-            <button class="view-option" data-view="covers" role="menuitem">
+            <button class="view-option btn-reset" data-view="covers" role="menuitem">
               <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"
                 ><rect x="1" y="1" width="4" height="6" rx="1"></rect><rect
                   x="6"
@@ -102,7 +103,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
               >
               Covers
             </button>
-            <button class="view-option" data-view="compact" role="menuitem">
+            <button class="view-option btn-reset" data-view="compact" role="menuitem">
               <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"
                 ><rect x="1" y="2" width="14" height="2" rx="1"></rect><rect
                   x="1"
@@ -136,7 +137,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
               {i > 0 && <span class="featured-sep">·</span>}
               <a
                 href={list.url}
-                class:list={['featured-link', { 'featured-bold': list.bold }]}
+                class:list={['featured-link link-quiet', { 'featured-bold': list.bold }]}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -154,7 +155,12 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
               {group.lists && (
                 <span class="genre-links">
                   {group.lists.map((list) => (
-                    <a href={list.url} class="genre-link" target="_blank" rel="noopener noreferrer">
+                    <a
+                      href={list.url}
+                      class="genre-link link-quiet"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       {list.name}
                     </a>
                   ))}
@@ -163,25 +169,14 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
             </div>
             <div class="poster-row" data-sortable>
               {group.movies.map((movie) => (
-                <div class="poster-card" data-year={movie.year}>
-                  <a
-                    href={movie.letterboxd}
-                    class="poster-link"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img src={movie.cover} alt={movie.name} class="poster-img" loading="lazy" />
-                  </a>
-                  <div class="poster-info">
-                    <span class="poster-name">{movie.name}</span>
-                    <span class="poster-meta">
-                      {movie.year} · {movie.director}
-                    </span>
-                    {movie.favouriteCast && (
-                      <span class="poster-meta poster-cast">{movie.favouriteCast.join(', ')}</span>
-                    )}
-                  </div>
-                </div>
+                <MediaCard
+                  name={movie.name}
+                  year={movie.year}
+                  cover={movie.cover}
+                  subtitle={`${movie.year} · ${movie.director}`}
+                  extra={movie.favouriteCast?.join(', ')}
+                  href={movie.letterboxd}
+                />
               ))}
             </div>
           </div>
@@ -195,18 +190,13 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
       <div class="poster-grid" data-sortable>
         {
           sortedFullSeries.map((show) => (
-            <div class="poster-card" data-year={show.year}>
-              <img src={show.cover} alt={show.name} class="poster-img" loading="lazy" />
-              <div class="poster-info">
-                <span class="poster-name">{show.name}</span>
-                <span class="poster-meta">
-                  {show.year} · {show.creator}
-                </span>
-                {show.favouriteCast && (
-                  <span class="poster-meta poster-cast">{show.favouriteCast.join(', ')}</span>
-                )}
-              </div>
-            </div>
+            <MediaCard
+              name={show.name}
+              year={show.year}
+              cover={show.cover}
+              subtitle={`${show.year} · ${show.creator}`}
+              extra={show.favouriteCast?.join(', ')}
+            />
           ))
         }
       </div>
@@ -218,18 +208,13 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
       <div class="poster-grid" data-sortable>
         {
           sortedMiniSeries.map((show) => (
-            <div class="poster-card" data-year={show.year}>
-              <img src={show.cover} alt={show.name} class="poster-img" loading="lazy" />
-              <div class="poster-info">
-                <span class="poster-name">{show.name}</span>
-                <span class="poster-meta">
-                  {show.year} · {show.creator}
-                </span>
-                {show.favouriteCast && (
-                  <span class="poster-meta poster-cast">{show.favouriteCast.join(', ')}</span>
-                )}
-              </div>
-            </div>
+            <MediaCard
+              name={show.name}
+              year={show.year}
+              cover={show.cover}
+              subtitle={`${show.year} · ${show.creator}`}
+              extra={show.favouriteCast?.join(', ')}
+            />
           ))
         }
       </div>
@@ -241,23 +226,20 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
       <div class="album-grid" data-sortable>
         {
           sortedMusic.map((album) => (
-            <div class="album-card" data-year={album.year}>
-              <a href={album.spotify} class="album-link" target="_blank" rel="noopener noreferrer">
-                <img src={album.cover} alt={album.name} class="album-img" loading="lazy" />
-              </a>
-              <div class="album-info">
-                <span class="album-name">{album.name}</span>
-                <span class="album-artist">
-                  {album.artist} · {album.year}
-                </span>
-                <span class="album-genres">{album.genres.join(', ')}</span>
-              </div>
-            </div>
+            <MediaCard
+              name={album.name}
+              year={album.year}
+              cover={album.cover}
+              subtitle={`${album.artist} · ${album.year}`}
+              extra={album.genres.join(', ')}
+              href={album.spotify}
+              aspectRatio="1 / 1"
+            />
           ))
         }
       </div>
     </section>
-    <button class="dark-toggle" id="dark-toggle" aria-label="Toggle dark mode">
+    <button class="dark-toggle icon-btn" id="dark-toggle" aria-label="Toggle dark mode">
       <svg
         class="dark-icon sun"
         viewBox="0 0 24 24"
@@ -309,18 +291,9 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     bottom: 1.25rem;
     right: 1.25rem;
     z-index: 20;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-border);
     color: var(--color-text-muted);
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s;
+    transition: all var(--transition-fast);
   }
 
   .dark-toggle:hover {
@@ -368,15 +341,11 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .tab-link {
-    font-size: 0.75rem;
+    font-size: var(--text-sm);
     font-weight: 500;
     color: var(--color-text-muted);
-    text-decoration: none;
-    padding: 0.25rem 0.5rem;
-    border-radius: 3px;
-    transition:
-      color 0.15s,
-      background 0.15s;
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
   }
 
   .tab-link:hover {
@@ -409,11 +378,11 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     border: 1px solid var(--color-border);
     color: var(--color-text-muted);
     padding: 0.2rem 0.45rem;
-    border-radius: 3px;
-    font-size: 0.7rem;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.15s;
+    transition: all var(--transition-fast);
   }
 
   .view-toggle:hover {
@@ -432,7 +401,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   .view-chevron {
     flex-shrink: 0;
     opacity: 0.6;
-    transition: transform 0.15s;
+    transition: transform var(--transition-fast);
   }
 
   :global(.view-dropdown.open) .view-chevron {
@@ -446,10 +415,10 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     right: 0;
     background: var(--color-bg-surface);
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-md);
     padding: 0.2rem;
     min-width: 100px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-dropdown);
     z-index: 20;
   }
 
@@ -461,16 +430,13 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   .view-option {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
-    background: none;
-    border: none;
+    gap: var(--space-xs);
     color: var(--color-text-muted);
-    padding: 0.3rem 0.5rem;
-    border-radius: 3px;
-    font-size: 0.7rem;
-    cursor: pointer;
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
     text-align: left;
-    transition: all 0.1s;
+    transition: all var(--transition-fast);
     width: 100%;
   }
 
@@ -488,11 +454,11 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     border: 1px solid transparent;
     color: var(--color-text-muted);
     padding: 0.2rem 0.5rem;
-    border-radius: 3px;
-    font-size: 0.7rem;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.15s;
+    transition: all var(--transition-fast);
   }
 
   .ctrl-btn:hover {
@@ -525,7 +491,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
   /* Sections */
   .section {
-    margin-bottom: 2.5rem;
+    margin-bottom: var(--space-lg);
   }
 
   .section-header {
@@ -536,7 +502,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .section-title {
-    font-size: 1rem;
+    font-size: var(--text-md);
     font-weight: 700;
     color: var(--color-text);
     margin: 0 0 0.75rem;
@@ -547,14 +513,14 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     color: var(--color-bg);
     border: none;
     padding: 0.2rem 0.55rem;
-    border-radius: 3px;
-    font-size: 0.65rem;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
     font-weight: 600;
     cursor: pointer;
     letter-spacing: 0.03em;
     transition:
-      background 0.15s,
-      transform 0.1s;
+      background var(--transition-fast),
+      transform var(--transition-fast);
   }
 
   .random-btn:hover {
@@ -568,7 +534,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
   /* Featured lists */
   .featured-lists {
-    font-size: 0.72rem;
+    font-size: var(--text-sm);
     color: var(--color-text-secondary);
     margin: 0 0 1.25rem;
     line-height: 1.6;
@@ -590,8 +556,6 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
   .featured-link {
     color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.15s;
   }
 
   .featured-link:hover {
@@ -615,7 +579,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .genre-title {
-    font-size: 0.7rem;
+    font-size: var(--text-xs);
     font-weight: 600;
     color: var(--color-text-muted);
     text-transform: uppercase;
@@ -629,10 +593,8 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .genre-link {
-    font-size: 0.65rem;
+    font-size: var(--text-xs);
     color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: color 0.15s;
   }
 
   .genre-link:hover {
@@ -657,234 +619,62 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     gap: 0.75rem;
   }
 
-  /* Shared poster card */
-  .poster-card {
-    display: flex;
-    flex-direction: column;
-    text-decoration: none;
-    color: inherit;
-  }
-
-  .poster-link {
-    display: block;
-  }
-
-  .poster-card:hover .poster-img {
-    opacity: 0.85;
-  }
-
-  .poster-img,
-  .tv-img {
-    background: var(--faves-shimmer, var(--color-bg-surface));
-    animation: pulse 2.5s ease-in-out infinite;
-  }
-
-  :global(.dark) .poster-img,
-  :global(.dark) .tv-img {
-    --faves-shimmer: #323238;
-  }
-
-  .poster-img[data-loaded],
-  .tv-img[data-loaded] {
-    animation: none;
-    background: none;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.6;
-    }
-  }
-
-  .poster-img {
-    width: 100%;
-    aspect-ratio: 2 / 3;
-    object-fit: cover;
-    border-radius: 3px;
-    transition: opacity 0.15s;
-  }
-
-  .poster-info {
-    display: flex;
-    flex-direction: column;
-    padding-top: 0.3rem;
-  }
-
-  .poster-name {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--color-text);
-    line-height: 1.25;
-  }
-
-  .poster-meta {
-    font-size: 0.68rem;
-    color: var(--color-text-muted);
-    line-height: 1.3;
-  }
-
-  .poster-cast {
-    color: var(--color-text-secondary);
-  }
-
-  :global(.poster-card.highlight) {
-    transform: scale(1.04);
-    z-index: 1;
-  }
-
-  :global(.poster-card.highlight) .poster-img {
-    outline: 3px solid var(--color-primary);
-    outline-offset: 2px;
-    box-shadow:
-      0 0 12px var(--color-primary),
-      0 4px 16px rgba(0, 0, 0, 0.3);
-    border-radius: 3px;
-  }
-
-  :global(.poster-card.highlight) .poster-name {
-    color: var(--color-primary);
-  }
-
-  /* Music */
+  /* Music grid */
   .album-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 1rem;
-  }
-
-  .album-card {
-    display: flex;
-    flex-direction: column;
-    transition: transform 0.15s;
-  }
-
-  .album-card:hover {
-    transform: scale(1.04);
-  }
-
-  .album-link {
-    display: block;
-  }
-
-  .album-img {
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    object-fit: cover;
-    border-radius: 3px;
-    transition: opacity 0.15s;
-  }
-
-  .album-info {
-    display: flex;
-    flex-direction: column;
-    padding-top: 0.3rem;
-  }
-
-  .album-name {
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--color-text);
-    line-height: 1.25;
-  }
-
-  .album-artist {
-    font-size: 0.68rem;
-    color: var(--color-text-muted);
-    line-height: 1.3;
-  }
-
-  .album-genres {
-    font-size: 0.68rem;
-    color: var(--color-text-secondary);
-    font-style: italic;
+    gap: var(--space-md);
   }
 
   /* ===== View: covers only ===== */
-  :global(.view-covers) .poster-info,
-  :global(.view-covers) .album-info {
+  :global(.view-covers) .media-info {
     display: none;
   }
 
-  :global(.view-covers) .poster-grid {
+  :global(.view-covers) .poster-grid,
+  :global(.view-covers) .album-grid {
     grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-    gap: 0.4rem;
+    gap: var(--space-xs);
   }
 
   :global(.view-covers) .poster-row {
-    gap: 0.4rem;
-  }
-
-  :global(.view-covers) .album-grid {
-    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-    gap: 0.4rem;
+    gap: var(--space-xs);
   }
 
   /* ===== View: compact list ===== */
   :global(.view-compact) .poster-row,
-  :global(.view-compact) .poster-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-  }
-
-  :global(.view-compact) .poster-card {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.3rem 0;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  :global(.view-compact) .poster-img {
-    width: 32px;
-    height: 48px;
-    flex-shrink: 0;
-    border-radius: 2px;
-  }
-
-  :global(.view-compact) .poster-info {
-    padding-top: 0;
-  }
-
-  :global(.view-compact) .poster-cast {
-    display: none;
-  }
-
-  :global(.view-compact) .poster-name {
-    font-size: 0.82rem;
-  }
-
+  :global(.view-compact) .poster-grid,
   :global(.view-compact) .album-grid {
     display: flex;
     flex-direction: column;
     gap: 0;
   }
 
-  :global(.view-compact) .album-card {
+  :global(.view-compact) .media-card {
     flex-direction: row;
     align-items: center;
-    gap: 0.6rem;
-    padding: 0.3rem 0;
+    gap: var(--space-sm);
+    padding: var(--space-xs) 0;
     border-bottom: 1px solid var(--color-border);
   }
 
-  :global(.view-compact) .album-img {
-    width: 40px;
-    height: 40px;
+  :global(.view-compact) .media-img {
+    width: 32px;
+    height: 48px;
     flex-shrink: 0;
     border-radius: 2px;
   }
 
-  :global(.view-compact) .album-info {
+  :global(.view-compact) .media-info {
     padding-top: 0;
   }
 
-  :global(.view-compact) .album-genres {
+  :global(.view-compact) .media-extra {
     display: none;
+  }
+
+  :global(.view-compact) .media-name {
+    font-size: var(--text-base);
   }
 
   /* ===== Responsive ===== */
@@ -912,12 +702,6 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     .toolbar-tabs {
       flex-wrap: wrap;
     }
-  }
-</style>
-
-<style is:global>
-  .theme-switcher {
-    display: none !important;
   }
 </style>
 
@@ -1005,7 +789,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
   // Random movie
   document.querySelector('#random-movie')?.addEventListener('click', () => {
-    const allCards = document.querySelectorAll<HTMLElement>('#movies .poster-card');
+    const allCards = document.querySelectorAll<HTMLElement>('#movies .media-card');
     if (allCards.length === 0) return;
 
     // Clear previous highlight
@@ -1041,7 +825,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   // Remove shimmer when images load
-  for (const img of document.querySelectorAll<HTMLImageElement>('.poster-img, .tv-img')) {
+  for (const img of document.querySelectorAll<HTMLImageElement>('.media-img')) {
     if (img.complete) {
       img.dataset.loaded = '';
     } else {

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -23,6 +23,6 @@ const projects = projectsData.projects;
     flex-wrap: wrap;
     justify-content: center;
     box-sizing: content-box;
-    padding: 1rem 0;
+    padding: var(--space-md) 0;
   }
 </style>

--- a/src/pages/secret.astro
+++ b/src/pages/secret.astro
@@ -1,0 +1,33 @@
+---
+import DefaultLayout from '../layouts/DefaultLayout.astro';
+import { site } from '../data/site';
+import { secretPages } from '../data/secret';
+---
+
+<DefaultLayout title={`${site.title} - secret`} description="You found it.">
+  <nav class="secret-nav flex-center">
+    {
+      secretPages.map((page) => (
+        <a href={page.path} class="link-quiet">
+          {page.name}
+        </a>
+      ))
+    }
+  </nav>
+</DefaultLayout>
+
+<style>
+  .secret-nav {
+    gap: var(--space-md);
+    min-height: 60vh;
+  }
+
+  .secret-nav a {
+    font-size: var(--text-lg);
+    color: var(--color-text);
+  }
+
+  .secret-nav a:hover {
+    color: var(--color-primary);
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,7 @@
 @import '@fontsource/lato/700.css';
 @import '@fontsource/open-sans/400.css';
 @import '@fontsource/open-sans/700.css';
+@import './utility.css';
 
 /* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
@@ -126,6 +127,7 @@ table {
 
 /* Design tokens */
 :root {
+  /* Colors */
   --color-text: rgb(33, 32, 40);
   --color-text-secondary: rgb(120, 120, 130);
   --color-text-muted: rgb(66, 66, 66);
@@ -141,7 +143,36 @@ table {
   --color-border: rgba(15, 15, 15, 0.4);
   --color-code-bg: rgb(235, 235, 240);
   --color-code-text: #2d2d2d;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+  --space-xl: 4rem;
+
+  /* Font sizes */
+  --text-xs: 0.7rem;
+  --text-sm: 0.75rem;
+  --text-base: 0.85rem;
+  --text-md: 1rem;
+  --text-lg: 1.25rem;
+  --text-xl: 1.5rem;
+
+  /* Border radius */
+  --radius-sm: 3px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-full: 100px;
+
+  /* Transitions */
+  --transition-fast: 0.15s;
+  --transition-normal: 0.3s;
+  --transition-slow: 0.5s;
+
+  /* Shadows */
   --shadow-button: 0 2px 3px rgba(0, 0, 0, 0.16), 0 2px 3px rgba(0, 0, 0, 0.23);
+  --shadow-dropdown: 0 4px 12px rgba(0, 0, 0, 0.15);
 
   /* Button tokens */
   --btn-border-width: 1px;
@@ -185,8 +216,8 @@ body {
   color: var(--color-text);
   background-color: var(--color-bg);
   transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
+    background-color var(--transition-slow) ease,
+    color var(--transition-slow) ease;
 }
 
 h1,
@@ -230,7 +261,7 @@ a {
   text-decoration-thickness: 0.1em;
   text-underline-offset: 2px;
   color: var(--color-secondary);
-  transition: color 0.3s ease;
+  transition: color var(--transition-normal) ease;
 }
 
 a:hover {
@@ -247,11 +278,11 @@ code {
   background-color: var(--color-code-bg) !important;
   color: var(--color-code-text) !important;
   transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
+    background-color var(--transition-slow) ease,
+    color var(--transition-slow) ease;
   padding: 2px 4px;
-  border-radius: 3px;
-  font-size: 0.85em;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
 }
 
 pre > code {

--- a/src/styles/utility.css
+++ b/src/styles/utility.css
@@ -1,0 +1,34 @@
+.flex-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.link-quiet {
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.btn-reset {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-bg-surface);
+  cursor: pointer;
+}

--- a/src/themes/definitions/sharks.ts
+++ b/src/themes/definitions/sharks.ts
@@ -25,6 +25,7 @@ const {
 });
 
 const BOUNCING_PUCK_CONFIG = { size: 62, speed: 1.5 };
+const SECRET_GOAL_THRESHOLD = 10;
 const CENTER_LOGO_MAX_WIDTH = '500px';
 const BACKGROUND_TILE_SIZE = '600px 500px';
 const GOAL_GIF_SIZE = '140px';
@@ -88,6 +89,7 @@ export default {
       <div class="goal-counter">
         <span class="goal-count"></span>
         <span class="goal-high"></span>
+        <a href="/secret" class="goal-secret">You found a secret.</a>
       </div>
     </div>
   `,
@@ -109,6 +111,8 @@ export default {
     .goal-counter { display: flex; flex-direction: column; align-items: flex-end; margin-top: 6px; font-family: 'Lato', sans-serif; font-weight: bold; text-shadow: 0 1px 3px rgba(0,0,0,0.5); }
     .goal-count { font-size: 1rem; color: ${PALETTE.orange}; }
     .goal-high { font-size: 0.75rem; color: ${PALETTE.textLight}; }
+    .goal-secret { display: none; font-size: 0.7rem; color: ${PALETTE.orange}; margin-top: 4px; pointer-events: auto; }
+    .goal-secret.revealed { display: block; }
   `,
 
   css: `
@@ -188,11 +192,15 @@ export default {
     const highEl = document.querySelector('.goal-high');
 
     const fin = createBouncer('.sharks-fin', { theme: THEME_ID, ...BOUNCING_PUCK_CONFIG });
+    const secretEl = document.querySelector('.goal-secret');
     fin?.addEventListener('click', () => {
       counter.increment();
       if (countEl) countEl.textContent = `Goals: ${counter.score}`;
       if (highEl) highEl.textContent = `Best: ${counter.highScore}`;
       goalPopup.show();
+      if (counter.score >= SECRET_GOAL_THRESHOLD) {
+        secretEl?.classList.add('revealed');
+      }
     });
   },
 } satisfies Theme;

--- a/src/utils/multiTap.ts
+++ b/src/utils/multiTap.ts
@@ -1,0 +1,32 @@
+export interface MultiTapOptions {
+  taps: number;
+  window?: number;
+}
+
+/**
+ * Calls `callback` when the element receives `taps` clicks
+ * within `window` milliseconds (default 600).
+ */
+export function onMultiTap(
+  element: HTMLElement,
+  callback: () => void,
+  { taps, window: tapWindow = 600 }: MultiTapOptions,
+): void {
+  let count = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  element.addEventListener('click', (e) => {
+    e.preventDefault();
+    count++;
+    if (timer) clearTimeout(timer);
+
+    if (count >= taps) {
+      count = 0;
+      callback();
+    } else {
+      timer = setTimeout(() => {
+        count = 0;
+      }, tapWindow);
+    }
+  });
+}


### PR DESCRIPTION
## Description

Major CSS cleanup and new features:

- Add CSS design tokens to `:root` for spacing, font sizes, border radius, transitions, and shadows — replacing ~100 hardcoded values across 13 files
- Consolidate 5 near-identical small font sizes (0.65–0.75rem) into 2 tokens (`--text-xs`, `--text-sm`)
- Add `utility.css` with shared classes (`flex-center`, `flex-col`, `link-quiet`, `btn-reset`, `icon-btn`) and apply them across components
- Extract unified `MediaCard.astro` component, replacing separate poster-card and album-card markup/styles in faves (net -150 lines CSS)
- Create `/secret` page as a hidden nav hub for all secret pages
- Add secret dropdown to site title (hover 3s or triple-tap, home page only)
- Add hidden link on 404 page pointing to `/secret`
- Add sharks theme easter egg (score 10 goals to reveal secret link)
- Show theme switcher on `/faves` and `/facts` pages
- Align scroll-to-top button with theme switcher (both at `bottom: 20px`)

## Testing

- Verified build, lint, typecheck all pass
- Verified `/facts` page renders with all sections and random fact button
- Verified `/secret` page renders with links to hidden pages
- Verified 404 page hidden link is invisible until hover
- Verified brand triple-tap reveals dropdown on home page only
- Verified brand link navigates to `/` normally on non-home pages
- Verified sharks theme secret link appears after 10 goals
- Verified MediaCard renders correctly for movies, TV, and albums
- Verified view modes (full, covers, compact) work with new MediaCard
- Verified theme switcher visible on `/faves` and `/facts`
- Verified responsive layout on mobile viewport