### PR TITLE
fix: address code review issues from #85

### DIFF
--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -25,7 +25,7 @@ const headerClass = [
   <div class="secret-dropdown" data-secret-dropdown>
     {
       secretPages.map((page) => (
-        <a href={page.path} class="secret-link">
+        <a href={page.path} class="secret-link link-quiet">
           {page.name}
         </a>
       ))
@@ -113,6 +113,18 @@ const headerClass = [
 
   [data-secret-dropdown][data-visible] {
     display: flex;
+  }
+
+  .secret-link {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+  }
+
+  .secret-link:hover {
+    color: var(--color-text);
+    background: var(--color-border);
   }
 
   @media (max-width: 576px) {

--- a/src/components/faves/MediaCard.astro
+++ b/src/components/faves/MediaCard.astro
@@ -83,7 +83,7 @@ const { name, year, cover, subtitle, extra, href, aspectRatio = '2 / 3' } = Astr
   }
 
   .media-info {
-    padding-top: 0.3rem;
+    padding-top: var(--space-xs);
   }
 
   .media-name {

--- a/src/data/facts.ts
+++ b/src/data/facts.ts
@@ -1,3 +1,4 @@
+// Fact text is rendered via set:html — only use trusted content here.
 export interface Fact {
   text: string;
   source?: string;

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -22,10 +22,4 @@ const { title, description, ogType } = Astro.props;
     min-width: 40vw;
     max-width: 100%;
   }
-
-  @media (max-width: 576px) {
-    .blog-content {
-      padding: 0 var(--space-md);
-    }
-  }
 </style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -31,10 +31,4 @@ const { title, description, headerTitle, siteTitle = site.title, ogType } = Astr
     flex-direction: column;
     flex: 1;
   }
-
-  @media (max-width: 576px) {
-    .container {
-      padding: 0 var(--space-md);
-    }
-  }
 </style>

--- a/src/pages/faves.astro
+++ b/src/pages/faves.astro
@@ -659,8 +659,8 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   :global(.view-compact) .media-img {
-    width: 32px;
-    height: 48px;
+    width: 36px;
+    aspect-ratio: auto;
     flex-shrink: 0;
     border-radius: 2px;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -282,7 +282,7 @@ code {
     color var(--transition-slow) ease;
   padding: 2px 4px;
   border-radius: var(--radius-sm);
-  font-size: var(--text-base);
+  font-size: 0.85em;
 }
 
 pre > code {


### PR DESCRIPTION
## Description

Fixes issues identified in the code review of #85:

- Restore `code` font-size to `0.85em` (relative) — was incorrectly changed to `rem` which breaks scaling in headings
- Remove no-op media queries from BlogLayout and PageLayout (both branches resolved to the same token value)
- Add missing styles and `link-quiet` class to secret dropdown links in Brand
- Fix compact view thumbnails to use `aspect-ratio: auto` so square album art isn't stretched to 2:3
- Add safety comment about `set:html` usage in facts.ts
- Revert unrelated PR template change that was accidentally included
- Replace last hardcoded `0.3rem` in MediaCard with `--space-xs` token

## Testing

- Build, lint, and typecheck pass
- `code` elements scale correctly inside headings
- Secret dropdown links have visible hover state and proper sizing
- Compact view preserves album square aspect ratio and poster portrait aspect ratio
- Blog and page layouts render correctly at all viewport widths