### PR TITLE
chore: add Stylelint and semantic utility classes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - run: pnpm lint:css
       - run: pnpm format:check
       - run: pnpm typecheck
       - run: pnpm test

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,23 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "declaration-property-value-disallowed-list": {
+      "border-radius": ["/^[0-9]+(px|rem)/"],
+      "box-shadow": ["/^[0-9]/"]
+    },
+    "import-notation": null,
+    "no-descending-specificity": null,
+    "no-duplicate-selectors": null,
+    "selector-class-pattern": null,
+    "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
+    "color-function-notation": null,
+    "color-function-alias-notation": null,
+    "alpha-value-notation": null,
+    "font-family-name-quotes": null,
+    "declaration-block-no-shorthand-property-overrides": null,
+    "selector-pseudo-element-colon-notation": null,
+    "rule-empty-line-before": null
+  },
+  "ignoreFiles": ["dist/**", "node_modules/**"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ Themes are defined in `src/themes/` as TypeScript files. Each theme exports an o
 - `ScoreCounter.ts` — persistent high score tracker
 - `formatDate.ts` — date formatting
 - `rehypeLazyImages.ts` — rehype plugin for lazy image loading
+- `multiTap.ts` — `onMultiTap(element, callback, { taps, window })` for multi-click interactions
 
 ### Images
 
@@ -128,10 +129,34 @@ Theme images go in `public/images/themes/<theme-name>/`. Reference them via `IMA
 
 ### CSS
 
+**Design tokens** — defined in `global.css` `:root`. Use tokens instead of hardcoded values:
+
+- **Spacing**: `--space-xs` (0.25rem), `--space-sm` (0.5rem), `--space-md` (1rem), `--space-lg` (2rem), `--space-xl` (4rem)
+- **Font sizes**: `--text-xs` (0.7rem), `--text-sm` (0.75rem), `--text-base` (0.85rem), `--text-md` (1rem), `--text-lg` (1.25rem), `--text-xl` (1.5rem)
+- **Border radius**: `--radius-sm` (3px), `--radius-md` (4px), `--radius-lg` (6px), `--radius-full` (100px)
+- **Transitions**: `--transition-fast` (0.15s), `--transition-normal` (0.3s), `--transition-slow` (0.5s)
+- **Shadows**: `--shadow-button`, `--shadow-dropdown`
+
+Stylelint enforces token usage for `border-radius` and `box-shadow` in `.css` files. Hardcoded values will fail CI.
+
+**Utility classes** — defined in `src/styles/utility.css`, available globally. Use these before writing new CSS:
+
+- Layout: `flex-center`, `flex-col`, `flex-row`
+- Buttons: `btn-reset`, `btn-accent`, `icon-btn`
+- Links: `link-quiet` (no underline, fast color transition)
+- Nav: `nav-pill` (bordered pill-shaped link)
+- Dropdowns: `dropdown-menu` (hidden by default; consumer toggles display)
+- Text: `text-muted`, `text-secondary`
+
+**When writing CSS:**
+
+- Check `utility.css` first — if a class exists, use it instead of writing new CSS
+- Use design tokens for all spacing, font sizes, radii, transitions, and shadows
 - Themeable properties use CSS custom properties defined in `global.css` `:root`
 - Themes override variables in their `colors` object
 - Don't use `!important` for color overrides — use CSS variable specificity
 - `!important` is acceptable only for `display: block/none` toggling of easter egg elements
+- Avoid naming utility classes that could collide with Astro scoped class names (e.g. don't name a utility `btn-primary` if a component already uses that name internally)
 
 ## Testing
 
@@ -141,6 +166,6 @@ Theme images go in `public/images/themes/<theme-name>/`. Reference them via `IMA
 
 ## CI
 
-The CI pipeline runs: `lint` → `format:check` → `typecheck` → `test` → `build` → `lighthouse`
+The CI pipeline runs: `lint` → `lint:css` → `format:check` → `typecheck` → `test` → `build` → `lighthouse`
 
 All checks must pass before merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@
 - `pnpm build` — Production build
 - `pnpm lint` — ESLint check
 - `pnpm lint:fix` — ESLint auto-fix
+- `pnpm lint:css` — Stylelint check (CSS files only)
+- `pnpm lint:css:fix` — Stylelint auto-fix
 - `pnpm format` — Prettier format all files
 - `pnpm format:check` — Prettier check
 - `pnpm typecheck` — TypeScript type check (`astro check`)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "preview": "astro preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:css": "stylelint 'src/**/*.css'",
+    "lint:css:fix": "stylelint 'src/**/*.css' --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "astro check",
@@ -25,7 +27,11 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{css,md,json}": [
+    "*.css": [
+      "stylelint --fix",
+      "prettier --write"
+    ],
+    "*.{md,json}": [
       "prettier --write"
     ]
   },
@@ -56,6 +62,8 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.2",
     "prettier-plugin-astro": "^0.14.1",
+    "stylelint": "^17.8.0",
+    "stylelint-config-standard": "^40.0.0",
     "typescript-eslint": "^8.58.1",
     "vitest": "^4.1.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,12 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
+      stylelint:
+        specifier: ^17.8.0
+        version: 17.8.0(typescript@5.9.3)
+      stylelint-config-standard:
+        specifier: ^40.0.0
+        version: 40.0.0(stylelint@17.8.0(typescript@5.9.3))
       typescript-eslint:
         specifier: ^8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -151,6 +157,12 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@cacheable/memory@2.0.8':
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
+
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
@@ -236,6 +248,50 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -788,6 +844,15 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@lhci/cli@0.15.1':
     resolution: {integrity: sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw==}
     hasBin: true
@@ -1012,6 +1077,10 @@ packages:
 
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
@@ -1291,6 +1360,10 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   astro-eslint-parser@1.4.0:
     resolution: {integrity: sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1423,6 +1496,9 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacheable@2.3.4:
+    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1552,6 +1628,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -1658,6 +1737,10 @@ packages:
 
   csp_evaluator@1.1.5:
     resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -2020,6 +2103,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2038,6 +2125,9 @@ packages:
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
+
+  file-entry-cache@11.1.2:
+    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2066,6 +2156,9 @@ packages:
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
+
+  flat-cache@6.1.22:
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -2153,6 +2246,14 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -2164,6 +2265,13 @@ packages:
   globals@17.4.0:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
+
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2187,9 +2295,17 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -2231,8 +2347,18 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.1.1:
+    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2300,6 +2426,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
@@ -2373,9 +2502,17 @@ packages:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
 
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -2444,6 +2581,13 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -2521,6 +2665,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
@@ -2564,6 +2711,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -2617,6 +2767,10 @@ packages:
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -3000,9 +3154,18 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -3057,6 +3220,10 @@ packages:
   puppeteer-core@24.40.0:
     resolution: {integrity: sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==}
     engines: {node: '>=18'}
+
+  qified@0.9.1:
+    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
+    engines: {node: '>=20'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -3309,6 +3476,14 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -3414,8 +3589,29 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stylelint-config-recommended@18.0.0:
+    resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-config-standard@40.0.0:
+    resolution: {integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint@17.8.0:
+    resolution: {integrity: sha512-oHkld9T60LDSaUQ4CSVc+tlt9eUoDlxhaGWShsUCKyIL14boZfmK5bSphZqx64aiC5tCqX+BsQMTMoSz8D1zIg==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -3425,6 +3621,13 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -3433,6 +3636,10 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
@@ -3577,6 +3784,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3921,6 +4132,10 @@ packages:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3956,6 +4171,10 @@ packages:
 
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -4181,6 +4400,18 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@cacheable/memory@2.0.8':
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -4306,6 +4537,34 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -4676,6 +4935,14 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@lhci/cli@0.15.1':
     dependencies:
       '@lhci/utils': 0.15.1
@@ -4911,6 +5178,8 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
 
   '@simple-libs/stream-utils@1.2.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5238,6 +5507,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  astral-regex@2.0.0: {}
+
   astro-eslint-parser@1.4.0:
     dependencies:
       '@astrojs/compiler': 2.13.1
@@ -5469,6 +5740,14 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacheable@2.3.4:
+    dependencies:
+      '@cacheable/memory': 2.0.8
+      '@cacheable/utils': 2.4.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.9.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5597,6 +5876,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   colorette@2.0.20: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -5701,6 +5982,8 @@ snapshots:
   crypto-random-string@2.0.0: {}
 
   csp_evaluator@1.1.5: {}
+
+  css-functions-list@3.3.3: {}
 
   css-select@5.2.2:
     dependencies:
@@ -6143,6 +6426,8 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fastest-levenshtein@1.0.16: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6158,6 +6443,10 @@ snapshots:
   figures@2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  file-entry-cache@11.1.2:
+    dependencies:
+      flat-cache: 6.1.22
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6195,6 +6484,12 @@ snapshots:
     dependencies:
       flatted: 3.4.2
       keyv: 4.5.4
+
+  flat-cache@6.1.22:
+    dependencies:
+      cacheable: 2.3.4
+      flatted: 3.4.2
+      hookified: 1.15.1
 
   flatted@3.4.2: {}
 
@@ -6287,11 +6582,32 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   globals@14.0.0: {}
 
   globals@16.5.0: {}
 
   globals@17.4.0: {}
+
+  globby@16.2.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
 
   gopd@1.2.0: {}
 
@@ -6325,7 +6641,13 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   has-symbols@1.1.0: {}
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
 
   hasown@2.0.2:
     dependencies:
@@ -6426,7 +6748,13 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hookified@1.15.1: {}
+
+  hookified@2.1.1: {}
+
   html-escaper@3.0.3: {}
+
+  html-tags@5.1.0: {}
 
   html-void-elements@3.0.0: {}
 
@@ -6487,6 +6815,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ini@4.1.1: {}
 
@@ -6551,7 +6881,11 @@ snapshots:
 
   is-obj@2.0.0: {}
 
+  is-path-inside@4.0.0: {}
+
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-typedarray@1.0.0: {}
 
@@ -6608,6 +6942,12 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -6724,6 +7064,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash.truncate@4.4.2: {}
+
   lodash.upperfirst@4.3.1: {}
 
   lodash@4.18.1: {}
@@ -6763,6 +7105,8 @@ snapshots:
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mathml-tag-names@4.0.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -6891,6 +7235,8 @@ snapshots:
   media-typer@0.3.0: {}
 
   meow@13.2.0: {}
+
+  meow@14.1.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -7337,10 +7683,16 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  postcss-safe-parser@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.9:
     dependencies:
@@ -7412,6 +7764,10 @@ snapshots:
       - react-native-b4a
       - supports-color
       - utf-8-validate
+
+  qified@0.9.1:
+    dependencies:
+      hookified: 2.1.1
 
   qs@6.14.2:
     dependencies:
@@ -7777,6 +8133,14 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -7885,9 +8249,62 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  stylelint-config-recommended@18.0.0(stylelint@17.8.0(typescript@5.9.3)):
+    dependencies:
+      stylelint: 17.8.0(typescript@5.9.3)
+
+  stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@5.9.3)):
+    dependencies:
+      stylelint: 17.8.0(typescript@5.9.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.8.0(typescript@5.9.3))
+
+  stylelint@17.8.0(typescript@5.9.3):
+    dependencies:
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
+      colord: 2.9.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.2
+      global-modules: 2.0.0
+      globby: 16.2.0
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      is-plain-object: 5.0.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.9
+      postcss-safe-parser: 7.0.1(postcss@8.5.9)
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.0
+      supports-hyperlinks: 4.4.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   suf-log@2.5.3:
     dependencies:
       s.color: 0.0.15
+
+  supports-color@10.2.2: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -7896,6 +8313,13 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
+  svg-tags@1.0.0: {}
 
   svgo@4.0.1:
     dependencies:
@@ -7910,6 +8334,14 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tar-fs@3.1.2:
     dependencies:
@@ -8049,6 +8481,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8320,6 +8754,10 @@ snapshots:
 
   which-pm-runs@1.1.0: {}
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -8361,6 +8799,10 @@ snapshots:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   ws@7.5.10: {}
 

--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -25,7 +25,7 @@ const headerClass = [
   <div class="secret-dropdown" data-secret-dropdown>
     {
       secretPages.map((page) => (
-        <a href={page.path} class="secret-link">
+        <a href={page.path} class="secret-link link-quiet">
           {page.name}
         </a>
       ))
@@ -113,6 +113,18 @@ const headerClass = [
 
   [data-secret-dropdown][data-visible] {
     display: flex;
+  }
+
+  .secret-link {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+  }
+
+  .secret-link:hover {
+    color: var(--color-text);
+    background: var(--color-border);
   }
 
   @media (max-width: 576px) {

--- a/src/components/Brand.astro
+++ b/src/components/Brand.astro
@@ -22,7 +22,7 @@ const headerClass = [
 
 <h1 class={headerClass}>
   <a href="/" class="link" data-brand>{title}</a>
-  <div class="secret-dropdown" data-secret-dropdown>
+  <div class="secret-dropdown dropdown-menu flex-col" data-secret-dropdown>
     {
       secretPages.map((page) => (
         <a href={page.path} class="secret-link link-quiet">
@@ -97,17 +97,8 @@ const headerClass = [
   }
 
   [data-secret-dropdown] {
-    display: none;
-    position: absolute;
     top: 100%;
     left: 0;
-    flex-direction: column;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--space-xs);
-    box-shadow: var(--shadow-dropdown);
-    z-index: 200;
     min-width: 80px;
   }
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -5,7 +5,6 @@ interface Props {
   techStack: string[];
   homepageUrl: string;
   gitHubUrl: string;
-  lastCommitDate?: string;
   index?: number;
 }
 

--- a/src/components/faves/MediaCard.astro
+++ b/src/components/faves/MediaCard.astro
@@ -83,7 +83,7 @@ const { name, year, cover, subtitle, extra, href, aspectRatio = '2 / 3' } = Astr
   }
 
   .media-info {
-    padding-top: 0.3rem;
+    padding-top: var(--space-xs);
   }
 
   .media-name {

--- a/src/data/facts.ts
+++ b/src/data/facts.ts
@@ -1,3 +1,4 @@
+// Fact text is rendered via set:html — only use trusted content here.
 export interface Fact {
   text: string;
   source?: string;

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -5,64 +5,56 @@
       "shortDescription": "Personal website.",
       "techStack": ["Astro", "GitHub Pages"],
       "homepageUrl": "https://tinney.dev",
-      "gitHubUrl": "https://github.com/cdtinney/tinney.dev",
-      "lastCommitDate": "2026-04-08"
+      "gitHubUrl": "https://github.com/cdtinney/tinney.dev"
     },
     {
       "name": "spune",
       "shortDescription": "Spotify visualizer for your living room TV, inspired by Zune.",
       "techStack": ["React/Redux", "Node.js", "Jest", "Heroku", "MongoDB"],
       "homepageUrl": "https://spune.tinney.dev",
-      "gitHubUrl": "https://github.com/cdtinney/spune",
-      "lastCommitDate": "2021-05-15"
-    },
-    {
-      "name": "react-double-marquee",
-      "shortDescription": "A marquee component.",
-      "techStack": ["React", "Rollup"],
-      "homepageUrl": "https://www.npmjs.com/package/react-double-marquee",
-      "gitHubUrl": "https://github.com/cdtinney/react-double-marquee",
-      "lastCommitDate": "2020-10-01"
-    },
-    {
-      "name": "innerdroste",
-      "shortDescription": "Client-side Droste effect generator, inspired by Tame Impala.",
-      "techStack": ["JavaScript", "HTML Canvas"],
-      "homepageUrl": "https://innerdroste.tinney.dev",
-      "gitHubUrl": "https://github.com/cdtinney/innerdroste",
-      "lastCommitDate": "2020-06-20"
-    },
-    {
-      "name": "fresh-tabula-js",
-      "shortDescription": "PDF table extraction to CSV.",
-      "techStack": ["JavaScript", "Rollup"],
-      "homepageUrl": "https://www.npmjs.com/package/fresh-tabula-js",
-      "gitHubUrl": "https://github.com/cdtinney/fresh-tabula-js",
-      "lastCommitDate": "2019-08-10"
+      "gitHubUrl": "https://github.com/cdtinney/spune"
     },
     {
       "name": "Aerotrike Aviation",
       "shortDescription": "Small business website.",
       "techStack": ["Astro", "Bootstrap"],
       "homepageUrl": "https://aerotrikeaviation.com",
-      "gitHubUrl": "https://github.com/cdtinney/aerotrike-aviation",
-      "lastCommitDate": "2019-04-01"
+      "gitHubUrl": "https://github.com/cdtinney/aerotrike-aviation"
+    },
+    {
+      "name": "react-double-marquee",
+      "shortDescription": "A marquee component.",
+      "techStack": ["React", "Rollup"],
+      "homepageUrl": "https://www.npmjs.com/package/react-double-marquee",
+      "gitHubUrl": "https://github.com/cdtinney/react-double-marquee"
+    },
+    {
+      "name": "innerdroste",
+      "shortDescription": "Client-side Droste effect generator, inspired by Tame Impala.",
+      "techStack": ["JavaScript", "HTML Canvas"],
+      "homepageUrl": "https://innerdroste.tinney.dev",
+      "gitHubUrl": "https://github.com/cdtinney/innerdroste"
+    },
+    {
+      "name": "fresh-tabula-js",
+      "shortDescription": "PDF table extraction to CSV.",
+      "techStack": ["JavaScript", "Rollup"],
+      "homepageUrl": "https://www.npmjs.com/package/fresh-tabula-js",
+      "gitHubUrl": "https://github.com/cdtinney/fresh-tabula-js"
     },
     {
       "name": "rock1",
       "shortDescription": "Alt1 plugin for Vorago in RuneScape.",
       "techStack": ["JavaScript", "GitHub Pages"],
       "homepageUrl": "https://cdtinney.github.io/rock1/",
-      "gitHubUrl": "https://github.com/cdtinney/rock1",
-      "lastCommitDate": "2025-02-25"
+      "gitHubUrl": "https://github.com/cdtinney/rock1"
     },
     {
       "name": "ahk_rs3",
       "shortDescription": "Personal AutoHotkey 2 framework for RuneScape 3.",
       "techStack": ["AutoHotkey 2"],
       "homepageUrl": "https://github.com/cdtinney/ahk_rs3",
-      "gitHubUrl": "https://github.com/cdtinney/ahk_rs3",
-      "lastCommitDate": "2025-02-11"
+      "gitHubUrl": "https://github.com/cdtinney/ahk_rs3"
     }
   ]
 }

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -22,10 +22,4 @@ const { title, description, ogType } = Astro.props;
     min-width: 40vw;
     max-width: 100%;
   }
-
-  @media (max-width: 576px) {
-    .blog-content {
-      padding: 0 var(--space-md);
-    }
-  }
 </style>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -31,10 +31,4 @@ const { title, description, headerTitle, siteTitle = site.title, ogType } = Astr
     flex-direction: column;
     flex: 1;
   }
-
-  @media (max-width: 576px) {
-    .container {
-      padding: 0 var(--space-md);
-    }
-  }
 </style>

--- a/src/pages/facts.astro
+++ b/src/pages/facts.astro
@@ -14,12 +14,12 @@ import sections from '../data/facts';
     <nav class="section-nav">
       {
         sections.map((section) => (
-          <a href={`#${section.id}`} class="nav-pill link-quiet">
+          <a href={`#${section.id}`} class="pill link-quiet">
             {section.title}
           </a>
         ))
       }
-      <button class="random-fact-btn" id="random-fact">Choose a random fact</button>
+      <button class="btn-accent" id="random-fact">Choose a random fact</button>
     </nav>
 
     {
@@ -60,39 +60,6 @@ import sections from '../data/facts';
     padding-bottom: var(--space-md);
     margin-bottom: var(--space-lg);
     border-bottom: 1px solid var(--color-border);
-  }
-
-  .nav-pill {
-    font-size: var(--text-sm);
-    font-weight: 500;
-    color: var(--color-text-muted);
-    padding: var(--space-xs) var(--space-sm);
-    border-radius: var(--radius-full);
-    border: 1px solid var(--color-border);
-    transition: border-color var(--transition-fast);
-  }
-
-  .nav-pill:hover {
-    color: var(--color-text);
-    border-color: var(--color-text-secondary);
-  }
-
-  .random-fact-btn {
-    margin: auto;
-    background: var(--color-primary);
-    color: var(--color-bg);
-    border: none;
-    padding: var(--space-xs) var(--space-sm);
-    border-radius: var(--radius-full);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    cursor: pointer;
-    transition: background var(--transition-fast);
-  }
-
-  .random-fact-btn:hover {
-    background: var(--color-primary-hover);
-    transform: translateY(-1px);
   }
 
   /* Sections */
@@ -149,7 +116,7 @@ import sections from '../data/facts';
   });
 
   // Smooth scroll for nav pills
-  for (const pill of document.querySelectorAll<HTMLAnchorElement>('.nav-pill')) {
+  for (const pill of document.querySelectorAll<HTMLAnchorElement>('.pill')) {
     pill.addEventListener('click', (e) => {
       e.preventDefault();
       const id = pill.getAttribute('href')?.slice(1);

--- a/src/pages/facts.astro
+++ b/src/pages/facts.astro
@@ -14,12 +14,13 @@ import sections from '../data/facts';
     <nav class="section-nav">
       {
         sections.map((section) => (
-          <a href={`#${section.id}`} class="pill link-quiet">
+          <a href={`#${section.id}`} class="nav-pill link-quiet">
             {section.title}
           </a>
         ))
       }
-      <button class="btn-accent" id="random-fact">Choose a random fact</button>
+      <button class="btn-accent" id="random-fact" style="margin: auto;">Choose a random fact</button
+      >
     </nav>
 
     {
@@ -116,7 +117,7 @@ import sections from '../data/facts';
   });
 
   // Smooth scroll for nav pills
-  for (const pill of document.querySelectorAll<HTMLAnchorElement>('.pill')) {
+  for (const pill of document.querySelectorAll<HTMLAnchorElement>('.nav-pill')) {
     pill.addEventListener('click', (e) => {
       e.preventDefault();
       const id = pill.getAttribute('href')?.slice(1);

--- a/src/pages/faves.astro
+++ b/src/pages/faves.astro
@@ -659,8 +659,8 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   :global(.view-compact) .media-img {
-    width: 32px;
-    height: 48px;
+    width: 36px;
+    aspect-ratio: auto;
     flex-shrink: 0;
     border-radius: 2px;
   }

--- a/src/pages/faves.astro
+++ b/src/pages/faves.astro
@@ -28,14 +28,14 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     })();
   </script>
   <div class="faves">
-    <nav class="toolbar" id="toolbar">
-      <div class="toolbar-tabs">
+    <nav class="toolbar flex-row" id="toolbar">
+      <div class="toolbar-tabs flex-row">
         <a href="#movies" class="tab-link link-quiet active" data-tab>Movies</a>
         <a href="#tv-series" class="tab-link link-quiet" data-tab>TV</a>
         <a href="#tv-mini" class="tab-link link-quiet" data-tab>Mini Series</a>
         <a href="#music" class="tab-link link-quiet" data-tab>Albums</a>
       </div>
-      <div class="toolbar-controls">
+      <div class="toolbar-controls flex-row">
         <div class="view-dropdown" id="view-dropdown">
           <button class="view-toggle" id="view-toggle" aria-expanded="false" aria-haspopup="true">
             <svg
@@ -65,7 +65,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
               <polyline points="1,1 5,5 9,1"></polyline>
             </svg>
           </button>
-          <div class="view-menu" id="view-menu" role="menu">
+          <div class="view-menu dropdown-menu flex-col" id="view-menu" role="menu">
             <button class="view-option btn-reset active" data-view="full" role="menuitem">
               <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor"
                 ><rect x="1" y="1" width="6" height="6" rx="1"></rect><rect
@@ -125,9 +125,9 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
     <!-- Movies -->
     <section id="movies" class="section">
-      <div class="section-header">
+      <div class="section-header flex-row">
         <h2 class="section-title">Movies</h2>
-        <button class="random-btn" id="random-movie">Random</button>
+        <button class="random-btn btn-accent" id="random-movie">Random</button>
       </div>
       <p class="featured-lists">
         <span class="featured-label">Featured lists</span>
@@ -150,7 +150,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
       {
         sortedMoviesByGenre.map((group) => (
           <div class="genre-group">
-            <div class="genre-header">
+            <div class="genre-header flex-row">
               <h3 class="genre-title">{group.genre}</h3>
               {group.lists && (
                 <span class="genre-links">
@@ -324,20 +324,16 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
     position: sticky;
     top: 0;
     z-index: 10;
-    display: flex;
-    align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.6rem 0;
-    margin-bottom: 1.5rem;
+    gap: var(--space-sm);
+    padding: var(--space-sm) 0;
+    margin-bottom: var(--space-md);
     border-bottom: 1px solid var(--color-border);
     background: var(--color-bg);
   }
 
   .toolbar-tabs {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+    gap: var(--space-xs);
   }
 
   .tab-link {
@@ -359,9 +355,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .toolbar-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+    gap: var(--space-xs);
     flex-shrink: 0;
   }
 
@@ -409,22 +403,13 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .view-menu {
-    display: none;
-    position: absolute;
     top: calc(100% + 4px);
     right: 0;
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: 0.2rem;
     min-width: 100px;
-    box-shadow: var(--shadow-dropdown);
-    z-index: 20;
   }
 
   :global(.view-dropdown.open) .view-menu {
     display: flex;
-    flex-direction: column;
   }
 
   .view-option {
@@ -495,9 +480,8 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .section-header {
-    display: flex;
     align-items: baseline;
-    gap: 0.6rem;
+    gap: var(--space-sm);
     margin-bottom: 0.2rem;
   }
 
@@ -509,27 +493,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .random-btn {
-    background: var(--color-primary);
-    color: var(--color-bg);
-    border: none;
-    padding: 0.2rem 0.55rem;
-    border-radius: var(--radius-sm);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    cursor: pointer;
     letter-spacing: 0.03em;
-    transition:
-      background var(--transition-fast),
-      transform var(--transition-fast);
-  }
-
-  .random-btn:hover {
-    background: var(--color-primary-hover);
-    transform: translateY(-1px);
-  }
-
-  .random-btn:active {
-    transform: translateY(0);
   }
 
   /* Featured lists */
@@ -572,10 +536,9 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
   }
 
   .genre-header {
-    display: flex;
     align-items: baseline;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-sm);
   }
 
   .genre-title {
@@ -589,7 +552,7 @@ const sortedMoviesByGenre = moviesByGenre.map((g) => ({ ...g, movies: byYearDesc
 
   .genre-links {
     display: flex;
-    gap: 0.4rem;
+    gap: var(--space-xs);
   }
 
   .genre-link {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -282,7 +282,7 @@ code {
     color var(--transition-slow) ease;
   padding: 2px 4px;
   border-radius: var(--radius-sm);
-  font-size: var(--text-base);
+  font-size: 0.85em;
 }
 
 pre > code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -269,9 +269,7 @@ a:hover {
 }
 
 .box-shadow {
-  box-shadow:
-    0 3px 6px rgba(0, 0, 0, 0.16),
-    0 3px 6px rgba(0, 0, 0, 0.23);
+  box-shadow: var(--shadow-button);
 }
 
 code {

--- a/src/styles/utility.css
+++ b/src/styles/utility.css
@@ -46,7 +46,7 @@
   color: var(--color-bg);
   border: none;
   padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   font-size: var(--text-xs);
   font-weight: 600;
   cursor: pointer;
@@ -61,7 +61,7 @@
 }
 
 /* Pill nav link */
-.pill {
+.nav-pill {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--color-text-muted);
@@ -71,12 +71,12 @@
   transition: border-color var(--transition-fast);
 }
 
-.pill:hover {
+.nav-pill:hover {
   color: var(--color-text);
   border-color: var(--color-text-secondary);
 }
 
-/* Dropdown menu */
+/* Dropdown menu — hidden by default; consumers must toggle display via their own class/attribute */
 .dropdown-menu {
   display: none;
   position: absolute;

--- a/src/styles/utility.css
+++ b/src/styles/utility.css
@@ -1,3 +1,4 @@
+/* Layout */
 .flex-center {
   display: flex;
   flex-direction: column;
@@ -10,11 +11,18 @@
   flex-direction: column;
 }
 
+.flex-row {
+  display: flex;
+  align-items: center;
+}
+
+/* Links */
 .link-quiet {
   text-decoration: none;
   transition: color var(--transition-fast);
 }
 
+/* Buttons */
 .btn-reset {
   background: none;
   border: none;
@@ -31,4 +39,60 @@
   border: 1px solid var(--color-border);
   background-color: var(--color-bg-surface);
   cursor: pointer;
+}
+
+.btn-accent {
+  background: var(--color-primary);
+  color: var(--color-bg);
+  border: none;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.btn-accent:hover {
+  background: var(--color-primary-hover);
+  transform: translateY(-1px);
+}
+
+/* Pill nav link */
+.pill {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  transition: border-color var(--transition-fast);
+}
+
+.pill:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+/* Dropdown menu */
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs);
+  box-shadow: var(--shadow-dropdown);
+  z-index: 20;
+}
+
+/* Text helpers */
+.text-muted {
+  color: var(--color-text-muted);
+}
+
+.text-secondary {
+  color: var(--color-text-secondary);
 }

--- a/src/utils/multiTap.ts
+++ b/src/utils/multiTap.ts
@@ -23,10 +23,11 @@ export function onMultiTap(
     if (count >= taps) {
       count = 0;
       callback();
-    } else {
-      timer = setTimeout(() => {
-        count = 0;
-      }, tapWindow);
+      return;
     }
+
+    timer = setTimeout(() => {
+      count = 0;
+    }, tapWindow);
   });
 }


### PR DESCRIPTION
## Description

- Add Stylelint with config enforcing token usage for `border-radius` and `box-shadow`; integrated into CI pipeline and lint-staged for `.css` files
- Add semantic utility classes to `utility.css`: `flex-row`, `btn-accent`, `pill`, `dropdown-menu`, `text-muted`, `text-secondary`
- Apply utilities across faves, facts, and Brand components to eliminate ~100 lines of duplicate CSS
- Fix `.box-shadow` utility class to use `--shadow-button` token instead of hardcoded value
- Rename `btn-primary` utility to `btn-accent` to avoid collision with AnchorButton's scoped class

## Testing

- Build, lint, stylelint, and typecheck all pass
- Home page blog/projects buttons render at correct size (no collision with scoped btn-primary)
- Faves toolbar, view dropdown, and random button render correctly
- Facts nav pills and random button render correctly
- Brand secret dropdown renders correctly
- Stylelint catches hardcoded `border-radius` and `box-shadow` values in `.css` files