### PR TITLE
feat: add useyourdamnhands to projects page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Projects are defined in `src/data/projects.json`. Sorted by `lastCommitDate` (ne
 
 This repo also hosts standalone microsites, each with its own domain, layout, and styles:
 
-- **[useyourdamnhands.com](https://useyourdamnhands.com)** — A public service announcement about single-purpose kitchen gadgets
+- **[useyourdamnhands.com](https://useyourdamnhands.com)** — A public service announcement about unnecessary tools
 - **[whatarewedoinghere.org](https://whatarewedoinghere.org)** — Coming soon
 
 Microsites live under `src/microsites/<name>/` (layouts, components, styles) and `src/pages/<name>/` (routes). Domain routing is handled by Cloudflare Pages Functions middleware (`functions/_middleware.ts`).

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -3,8 +3,15 @@
     {
       "name": "tinney.dev",
       "shortDescription": "Personal website.",
-      "techStack": ["Astro", "GitHub Pages"],
+      "techStack": ["Astro", "Cloudflare Pages"],
       "homepageUrl": "https://tinney.dev",
+      "gitHubUrl": "https://github.com/cdtinney/tinney.dev"
+    },
+    {
+      "name": "useyourdamnhands.com",
+      "shortDescription": "A public service announcement about unnecessary tools.",
+      "techStack": ["Astro", "Cloudflare Pages"],
+      "homepageUrl": "https://useyourdamnhands.com",
       "gitHubUrl": "https://github.com/cdtinney/tinney.dev"
     },
     {


### PR DESCRIPTION
## Description

Add useyourdamnhands.com to the projects page. Also updates the tinney.dev tech stack from "GitHub Pages" to "Cloudflare Pages" and the README microsite description.

## Testing

- Projects page renders with the new useyourdamnhands.com card
- Homepage URL links to https://useyourdamnhands.com
- GitHub URL links to the tinney.dev repo (since the site is now hosted here)