### PR TITLE
docs: update FORKING.md with Cloudflare Pages deploy steps

### DIFF
--- a/FORKING.md
+++ b/FORKING.md
@@ -27,22 +27,31 @@ export const site = {
 
 ### 2. Update `astro.config.mjs`
 
-Set your domain (or GitHub Pages URL):
+Set your domain — this is used for sitemap and canonical URLs:
 
 ```js
 site: 'https://your-domain.com',
 ```
 
-### 3. Update `public/CNAME`
+If you remove the microsites (see step 4), also remove them from the sitemap `filter`.
 
-Replace with your custom domain, or delete this file if using `username.github.io`.
-
-### 4. Replace your content
+### 3. Replace your content
 
 - **Projects** — edit `src/data/projects.json` with your own projects
 - **Blog posts** — replace or remove posts in `src/content/blog/`
 - **OG image** — replace `public/og-image.png` with your own (1200x630 recommended)
 - **Favicon** — replace `public/favicon.png`
+
+### 4. Remove or replace microsites
+
+This repo hosts standalone microsites (`useyourdamnhands.com`, `whatarewedoinghere.org`) alongside the main site. If you don't need them:
+
+- Delete `src/microsites/`, `src/pages/hands/`, `src/pages/whatarewedoinghere/`, `public/hands/`
+- Remove the microsite entries from `MICROSITES` in `functions/_middleware.ts` (or delete the file entirely if you have no multi-domain routing)
+- Remove the microsite `filter` from `astro.config.mjs`
+- Remove microsite links from the homepage and projects page
+
+To add your own microsite, see the "Microsites" section in `CLAUDE.md` for the file structure and conventions.
 
 ### 5. Update metadata files
 
@@ -50,9 +59,28 @@ Replace with your custom domain, or delete this file if using `username.github.i
 - `LICENSE` — update the copyright holder
 - `README.md` — update the title and CI badge URL
 
-### 6. Deploy
+### 6. Deploy to Cloudflare Pages
 
-The site deploys to GitHub Pages via GitHub Actions on push to `main`. Enable GitHub Pages in your repo settings (Settings > Pages > Source: GitHub Actions).
+The site deploys to Cloudflare Pages via GitHub Actions (`.github/workflows/main.yml`) using `wrangler pages deploy`.
+
+**One-time setup:**
+
+1. Create a Cloudflare Pages project in the Cloudflare dashboard (Workers & Pages → Create → Pages → Direct Upload). Name it something like `your-site` — you'll reference this name in the workflow.
+2. Update the `--project-name=tinney-dev` flags in `.github/workflows/main.yml` (two places: `deploy` and `preview` jobs) to match your project name.
+3. Create a Cloudflare API token (My Profile → API Tokens → Create Token → "Edit Cloudflare Workers" template, or a custom token with `Account.Cloudflare Pages: Edit` permission).
+4. In your GitHub repo, add two Actions secrets:
+   - `CLOUDFLARE_API_TOKEN` — the token from step 3
+   - `CLOUDFLARE_ACCOUNT_ID` — found in the Cloudflare dashboard sidebar
+5. Add your custom domain(s) in the Cloudflare Pages project settings (Custom domains tab). Cloudflare handles DNS and SSL automatically when the domain is on Cloudflare, or provides CNAME instructions for external DNS.
+
+**How it works:**
+
+- **Production** — pushes to `main` deploy via `wrangler pages deploy --branch=main`
+- **Preview** — pull requests deploy via `wrangler pages deploy --branch=<head_ref>`, and a preview URL (e.g. `feat-my-thing.your-site.pages.dev`) is posted as a PR comment
+
+### 7. (Optional) Multi-domain routing
+
+If you want to host multiple sites under one Cloudflare Pages project (like this repo does with microsites), the middleware in `functions/_middleware.ts` rewrites requests based on the `Host` header. Edit the `MICROSITES` array to map custom domains to URL path prefixes. Each microsite domain must also be added as a custom domain in the Cloudflare Pages dashboard.
 
 ## What you don't need to change
 


### PR DESCRIPTION
## Description

Rewrites FORKING.md to reflect the current Cloudflare Pages deployment and multi-domain microsite setup. The previous version described GitHub Pages deployment and referenced a `public/CNAME` file that no longer exists.

Key additions:
- Cloudflare Pages setup (creating the Pages project, required GitHub Actions secrets, updating the `--project-name` in the workflow, configuring custom domains)
- A step for removing or replacing the microsites when forking (files to delete in `src/microsites/`, `src/pages/`, `public/`, plus middleware and sitemap filter cleanup)
- An optional multi-domain routing section pointing at `functions/_middleware.ts`
- Note that `astro.config.mjs`'s sitemap `filter` needs updating if microsites are removed

## Testing

- Rendered the updated FORKING.md locally and confirmed formatting
- Cross-checked each step against `.github/workflows/main.yml`, `functions/_middleware.ts`, and `astro.config.mjs` to make sure references and flags are accurate